### PR TITLE
Update to match v1.1.0 firmware

### DIFF
--- a/blacs_tabs.py
+++ b/blacs_tabs.py
@@ -14,14 +14,14 @@ class PrawnDOTab(DeviceTab):
 
         self.com_port = device.properties['com_port']
 
-        self.supports_remote_value_check(False)
-        self.supports_smart_programming(False)
+        self.supports_remote_value_check(True)
+        self.supports_smart_programming(True)
 
 
     def initialise_workers(self):
         self.create_worker(
             "main_worker",
-            "naqslab_devices.prawn_do.blacs_workers.PrawnDOWorker",
+            "naqslab_devices.prawn_digital_output_labscript.blacs_workers.PrawnDOWorker",
             {
                 'com_port': self.com_port,
             },

--- a/blacs_workers.py
+++ b/blacs_workers.py
@@ -77,11 +77,7 @@ class PrawnDOInterface(object):
         Returns response, throws serial exception on disconnect.'''
         self.conn.write('add\n'.encode())
         self.conn.write('0x{:04x} '.format(bit_set).encode())
-        if reps == 0:
-            self.conn.write('0x{:08x} '.format(reps).encode())
-            self.conn.write('1\n'.encode())
-        else:
-            self.conn.write('0x{:08x}\n'.format(reps).encode())
+        self.conn.write('0x{:08x}\n'.format(reps).encode())
         self.conn.write('end\n'.encode())
         return self.conn.read_until(b'> ')
     
@@ -99,12 +95,8 @@ class PrawnDOInterface(object):
         '''Sends 'add' commands for each bit_set in bit_sets list. Returns response.'''
         self.conn.write('add\n'.encode())
         for i in range(0, len(reps)):
-            self.conn.write('0x{:04x} '.format(bit_sets[i]).encode())
-            if reps == 0:
-                self.conn.write('0x{:08x} '.format(reps[i]).encode())
-                self.conn.write('1\n'.encode())
-            else:
-                self.conn.write('0x{:08x}\n'.format(reps[i]).encode())
+            self.conn.write('0x{:04x} '.format(bit_sets[i]).encode()) 
+            self.conn.write('0x{:08x}\n'.format(reps[i]).encode())
         self.conn.write('end\n'.encode())
         return self.conn.read_until(b'> ')
 

--- a/blacs_workers.py
+++ b/blacs_workers.py
@@ -199,14 +199,19 @@ class PrawnDOWorker(Worker):
         Returns:
             bool: `True` if transition to manual is successful.
         """
+        i = 0
         while True:
             run_status, _ = self.intf.status()
+            i += 1
             if run_status == 0:
-                break
+                return True
+            elif i == 1000:
+                # program hasn't ended, probably bad triggering
+                # abort and raise an error
+                self.abort_buffered()
+                raise LabscriptError(f'PrawnDO did not end with status {run_status:d}. Is triggering working?')
             elif run_status in [3,4,5]:
                 raise LabscriptError(f'PrawnDO returned status {run_status} in transition to manual')
-            
-        return True
 
     def abort_buffered(self):
         """Aborts a currently running buffered execution.

--- a/blacs_workers.py
+++ b/blacs_workers.py
@@ -1,155 +1,232 @@
 from blacs.tab_base_classes import Worker
 import labscript_utils.h5_lock, h5py
+import labscript_utils
+from labscript import LabscriptError
 import numpy as np
+import re
+import time
 
 class PrawnDOInterface(object):
     def __init__(self, com_port):
         global serial; import serial
 
-        self.timeout = 10
+        self.timeout = 0.5
         self.conn = serial.Serial(com_port, 10000000, timeout=self.timeout)
 
-        self.clear()
-        if not self.clear():
-            raise RuntimeError('Unable to communicate with PrawnDO Pico')
-
-    def clear(self):
-        '''Sends 'cls' command, w
+        ver = self.send_command('ver')
+        print(f'Connected: {ver:s}')
         
-        ch clears the currently stored run.
-        Returns response, throws serial exception on disconnect.'''
-        self.conn.write(b'cls\n')
-        # Note that read_until should read until the prompt, not newline
-        return self.conn.read_until(b'> ')
+    def send_command(self, command, readlines=False):
+        '''Sends the supplied string command and checks for a response.
+        
+        Automatically applies the correct termination characters.
+        
+        Args:
+            command (str): Command to send. Termination and encoding is done automatically.
+            readlines (bool, optional): Use pyserial's readlines functionality to read multiple
+                response lines. Slower as it relies on timeout to terminate reading.
 
-    def abort(self):
-        '''Sends 'abt' command, which stops the current run (or does nothing if no run).
-        Returns response, throws serial exception on disconnect.'''
-        self.conn.write(b'abt\n')
-        return self.conn.read_until(b'> ')
+        Returns:
+            str: String response from the PrawnDO
+        '''
+        command += '\r\n'
+        self.conn.write(command.encode())
 
-    def run(self):
-        '''Sends 'run' command, which starts the current run.
-        Returns response, throws serial exception on disconnect.'''
-        self.conn.write(b'run\n')
-        return self.conn.read_until(b'> ')
+        if readlines:
+            resp = self.conn.readlines()
+            str_resp = ''.join([st.decode() for st in resp])
+        else:
+            str_resp = self.conn.readline().decode()
 
-    def dump(self):
-        '''Sends 'dmp' command, which dumps the currently loaded run.
-        Returns the dump of the run.'''
-        self.conn.write(b'dmp\n')
-        return self.conn.read_until(b'> ')
+        return str_resp
     
-    def clock_external(self):
-        '''Sends 'run' command, which starts the current run.
-        Returns response, throws serial exception on disconnect.'''
-        self.conn.write(b'clk ext\n')
-        return self.conn.read_until(b'> ')
-    
-    def clock_internal(self):
-        '''Sends 'run' command, which starts the current run.
-        Returns response, throws serial exception on disconnect.'''
-        self.conn.write(b'clk int\n')
-        return self.conn.read_until(b'> ')
-    
-    def clock_set(self, frequency):
-        '''Sends 'run' command, which starts the current run.
-        Returns response, throws serial exception on disconnect.'''
-        self.conn.write(b'clk set ')
+    def send_command_ok(self, command):
+        '''Sends the supplied string command and confirms 'ok' response.
+        '''
 
-        self.conn.write('d\n'.format(frequency).encode())
-        return self.conn.read_until(b'> ')
+        resp = self.send_command(command)
+        if resp != 'ok\r\n':
+            raise LabscriptError(f"Command '{command:s}' failed. Got response '{resp}'")
     
-    def current(self):
-        '''Sends 'run' command, which starts the current run.
-        Returns response, throws serial exception on disconnect.'''
-        self.conn.write(b'cur\n')
-        return self.conn.read_until(b'> ')
-    
-    def version(self):
-        '''Sends 'run' command, which starts the current run.
-        Returns response, throws serial exception on disconnect.'''
-        self.conn.write(b'ver\n')
-        return self.conn.read_until(b'> ')
+    def status(self):
+        '''Reads the status of the PrawnDO
+        
+        Returns:
+            (int, int): tuple containing
 
-    def add(self, bit_set, reps):
-        '''Sends 'add' command for a single set of output bits
-        Returns response, throws serial exception on disconnect.'''
-        self.conn.write('add\n'.encode())
-        self.conn.write('0x{:04x} '.format(bit_set).encode())
-        self.conn.write('0x{:08x}\n'.format(reps).encode())
-        self.conn.write('end\n'.encode())
-        return self.conn.read_until(b'> ')
-    
-    def edit(self, bit_set, reps):
-        '''Sends 'add' command for a single set of output bits
-        Returns response, throws serial exception on disconnect.'''
-        self.conn.write('edt\n'.encode())
-        self.conn.write('0x{:04x} '.format(bit_set).encode())
-         # Send bits as hex string
-        self.conn.write('0x{:08x}\n'.format(reps).encode()) # Send bits as hex string
-        return self.conn.read_until(b'> ')
-
+                - **run-status** (int): Run status code
+                - **clock-status** (int): Clock status code
+        '''
+        resp = self.send_command('sts')
+        match = re.match(r"run-status:(\d) clock-status:(\d)(\r\n)?", resp)
+        if match:
+            return int(match.group(1)), int(match.group(2))
+        else:
+            raise LabscriptError('PrawnDO invalid status, returned {resp}')
 
     def add_batch(self, bit_sets, reps):
         '''Sends 'add' commands for each bit_set in bit_sets list. Returns response.'''
         self.conn.write('add\n'.encode())
         for i in range(0, len(reps)):
-            self.conn.write('0x{:04x} '.format(bit_sets[i]).encode()) 
-            self.conn.write('0x{:08x}\n'.format(reps[i]).encode())
+            self.conn.write('{:04x} '.format(bit_sets[i]).encode()) 
+            self.conn.write('{:08x}\n'.format(reps[i]).encode())
         self.conn.write('end\n'.encode())
-        return self.conn.read_until(b'> ')
+        resp = self.conn.readline().decode()
+        assert resp == 'ok\r\n', f'Program not written successfully, got response {resp}'
 
     def close(self):
         self.conn.close()
 
 class PrawnDOWorker(Worker):
     def init(self):
-        self.intf = PrawnDOInterface(self.com_port)
+        self.intf = PrawnDOInterface(self.com_port)        
+
+        self.smart_cache = {'do_table':None, 'reps':None}
+
+    def _dict_to_int(self, d):
+        """Converts dictionary of outputs to an integer mask.
+        
+        Args:
+            d (dict): Dictionary of output states
+
+        Returns:
+            int: Integer mask of the 16 output states.
+        """
+        val = 0
+        for conn, value in d.items():
+            val |= value << int(conn, 16)
+
+        return val
+    
+    def _int_to_dict(self, val):
+        """Converts an integer mask to a dictionary of outputs.
+        
+        Args:
+            val (int): 16-bit integer mask to convert
+            
+        Returns:
+            dict: Dictonary with output channels as keys and values are boolean states
+        """
+        return {hex(i):((val >> i) & 1) for i in range(16)}
+    
+    def check_status(self):
+        '''Checks operational status of the PrawnDO.
+
+        Automatically called by BLACS to update status.
+
+        Returns:
+            (int, int): Tuple containing:
+
+            - **run-status** (int): Possible values are:
+
+              * 0 : manual mode
+              * 1 : transitioning to buffered execution
+              * 2 : buffered execution
+              * 3 : abort requested
+              * 4 : aborting buffered execution
+              * 5 : last buffered execution aborted
+              * 6 : transitioning to manual mode
+
+            - **clock-status** (int): Possible values are:
+
+              * 0 : internal clock
+              * 1 : external clock
+        '''
+
+        return self.intf.status()
 
     def program_manual(self, front_panel_values):
-        self.intf.abort() # stop current run, if it is happening
-        self.intf.clear() # clear current Pi Pico buffer
+        """Change output states in manual mode.
+        
+        Returns:
+            dict: Output states after command execution.
+        """
+        value = self._dict_to_int(front_panel_values)
+        # send static state
+        self.intf.send_command_ok(f'man {value:04x}')
+        # confirm state set correctly
+        resp = self.intf.send_command('gto')
 
-        values = np.zeros(1, dtype=np.uint16) # Make 16 bit unsigned integer
-        for conn, value in front_panel_values.items():
-            # "Or" each bit from the front panel into the integer
-            values[0] |= value << (int(conn, 16))
-        # Send to the Pi Pico
-        #self.intf.add(0, 0)
-        self.intf.add(values[0], 0)
+        return self._int_to_dict(int(resp, 16))
+    
+    def check_remote_values(self):
+        """Checks the remote state of the PrawnDO.
+        
+        Called automatically by BLACS.
+        
+        Returns:
+            dict: Dictionary of the digital output states.
+        """
+        resp = self.intf.send_command('gto')
 
-        self.intf.run()
+        return self._int_to_dict(int(resp, 16))
 
     def transition_to_buffered(self, device_name, h5file, initial_values, fresh):
-        self.intf.abort() # stop current run, if it is happening
-        self.intf.clear() # clear current Pi Pico buffer
+
+        if fresh:
+            self.smart_cache = {'do_table':None, 'reps':None}
 
         with h5py.File(h5file, 'r') as hdf5_file:
             group = hdf5_file['devices'][device_name]
-            do_table = group['do_data']
-            reps = group['reps_data']
-            do_table = list(do_table)
-            reps = list(reps)
-            # The data "table" contains only a single column of integers, so just convert to list
-            # Need to append an initial zero, since first output occurs immediately (before trigger)
-            if len(reps) <= 23000:
-                self.intf.add_batch([0] + do_table, [0] + reps)
+            self.device_properties = labscript_utils.properties.get(
+                hdf5_file, device_name, "device_properties")
+            do_table = group['do_data'][()]
+            reps = group['reps_data'][()]
 
-        self.intf.run()
+        # configure clock from device properties
+        ext = self.device_properties['external_clock']
+        freq = self.device_properties['clock_frequency']
+        self.intf.send_command_ok(f"clk {ext:d} {freq:.0f}")
+            
+        # only program if things differ from smart cache
+        if not (np.array_equal(do_table, self.smart_cache['do_table']) and
+                np.array_equal(reps, self.smart_cache['reps'])):
+            self.intf.send_command_ok('cls') # clear old program
+            self.intf.add_batch(do_table, reps)
+            self.smart_cache['do_table'] = do_table
+            self.smart_cache['reps'] = reps
 
-        return {}
+        final_values = self._int_to_dict(do_table[-1])
+
+        # start program, waiting for beginning trigger from parent
+        self.intf.send_command_ok('run')
+
+        return final_values
 
     def transition_to_manual(self):
+        """Transition to manual mode after buffered execution completion.
+        
+        Returns:
+            bool: `True` if transition to manual is successful.
+        """
+        while True:
+            run_status, _ = self.intf.status()
+            if run_status == 0:
+                break
+            elif run_status in [3,4,5]:
+                raise LabscriptError(f'PrawnDO returned status {run_status} in transition to manual')
+            
         return True
 
     def abort_buffered(self):
-        self.intf.abort()
+        """Aborts a currently running buffered execution.
+        
+        Returns:
+            bool: `True` is abort was successful.
+        """
+        self.intf.send_command_ok('abt')
+        # loop until abort complete
+        while self.intf.status()[0] != 5:
+            time.sleep(0.5)
         return True
 
     def abort_transition_to_buffered(self):
-        self.intf.abort()
-        return True
+        """Aborts transition to buffered.
+        
+        Calls :meth:`abort_buffered`
+        """
+        return self.abort_buffered()
 
     def shutdown(self):
+        """Closes serial connection to PrawnDO"""
         self.intf.close()

--- a/labscript_devices.py
+++ b/labscript_devices.py
@@ -4,25 +4,39 @@ import numpy as np
 class Pod(Output):
     allowed_children = [DigitalOut]
 
-    def __init__(self, name, parent_device, connection, default_value, **kwargs):
-
-        Output.__init__(self, name, parent_device, connection, None, None, None, default_value, **kwargs)
+    def __init__(self, name, parent_device, min_duration,
+                 connection='internal', **kwargs):
+        """Collective output class for the PrawnDO.
         
+        This class aggregates the 16 individual digital outputs of the PrawnDO.
+        It is for internal use of the PrawnDO only.
 
+        Args:
+            name (str): name to assign
+            parent_device (Device): Parent device PrawnDO is connected to
+            min_duration (float): Minimum time between updates on the outputs, in seconds.
+            connection (str, optional): Connection, ignored by default.
+        """
+
+        self.min_duration = min_duration
+        Output.__init__(self, name, parent_device, connection,
+                        None, None, None, 0, **kwargs)
 
     def generate_code(self, hdf5_file):
         Output.generate_code(self, hdf5_file)
 
 
-    # Method used to calculate and return the times where the digital outputs
-    # change state to the PrawnDO Intermediate Device
     def get_update_times(self):
+        """Overridden method that collects and condenses update times across all 16 outputs."""
+        # TODO: this is very fragile to timing edge cases
         # Creating a sorted numpy array to store the update times
         update_times = []
         update_times = np.asarray(update_times)
         # Looping through each output to add their unique update times to the
         # sorted array
         for output in self.child_devices:
+            # do checks on instructions, ensures all outputs have a default state
+            output.do_checks((0,))
             # Checking each update time of each output to see if it is unique
             # enough (>= 50ns difference compared to other times)
             for time in output.get_change_times():
@@ -35,13 +49,13 @@ class Pod(Output):
                     # in the list, just check to make sure its greater by 50ns
                     # and if it is, append to the array
                     elif update_times[-1] < time:
-                        if (time - update_times[-1] >= 49e-9):
+                        if (time - update_times[-1] >= self.min_duration):
                             update_times = np.append(update_times, time) 
                     # If this time is less than the smallest value in the list,
                     # just check that it's smaller by at least 50 ns, then 
                     # insert at the beginning of the array
                     elif update_times[0] > time:
-                        if (update_times[0] - time >= 49e-9):
+                        if (update_times[0] - time >= self.min_duration):
                             update_times = np.insert(update_times, 0, time)   
                     # If the time is located not at the beginning or end,
                     # check both the greater and lesser values, and if the
@@ -49,79 +63,128 @@ class Pod(Output):
                     # insert between those two existing time values                         
                     else: 
                         index = np.searchsorted(update_times, time)
-                        if(time - update_times[index - 1] >= 49e-9) and (update_times[index] - time >= 49e-9):
+                        if ((time - update_times[index - 1] >= self.min_duration) 
+                            and (update_times[index] - time >= self.min_duration)):
+                            
                             update_times = np.insert(update_times, index, time)
                     
         return update_times
-    # Overriding the get_all_outputs method in order to prevent the parent
-    # Pseudoclock from pulsing for each output's change of state
+
     def get_all_outputs(self):
+        """Overridden in order to prevent parent Pseudoclock from ticking
+        for each output's change of state"""
         return []
     
 
 class PrawnDO(IntermediateDevice):
+    description = "PrawnDO"
+
+    # default specs assuming 100MHz system clock
+    resolution = 10e-9
+    "Minimum resolvable unit of time, corresponsd to system clock period."
+    minimum_duration = 50e-9
+    "Minimum time between updates on the outputs."
+    wait_delay = 40e-9
+    "Minimum required length of wait before a retrigger can be detected."
+
     allowed_children = [Pod, DigitalOut]
+
+    max_instructions = 23010
+    """Maximum number of instructions. Set by zmq timeout when sending the commands."""
 
     @set_passed_properties(
         property_names={
             'connection_table_properties': [
-                'name',
                 'com_port',
+            ],
+            'device_properties': [
+                'clock_frequency',
+                'external_clock',
+                'resolution',
+                'minimum_duration',
+                'wait_delay',
             ]
         }
     )
 
 
-    def __init__(self, name, parent_device, com_port, **kwargs):
+    def __init__(self, name, parent_device, com_port,
+                 clock_frequency = 100e6,
+                 external_clock = False,
+                 **kwargs):
+        """PrawnDO digital output device.
+        
+        This labscript device provides general purpose digital outputs
+        using a Raspberry Pi Pico with custom firmware.
+
+        Args:
+            name (str): python variable name to assign to the PrawnDO
+            parent_device (:class:`~labscript.Device`): Device that will send the
+                starting hardware trigger.
+            com_port (str): COM port assinged to the PrawnDO by the OS.
+                Takes the form of `COMd` where `d` is an integer.
+            clock_frequency (float, optional): System clock frequency, in Hz.
+                Must be less than 133 MHz. Default is `100e6`.
+            external_clock (bool, optional): Whether to use an external clock.
+                Default is `False`.
+        """
+
+        if clock_frequency > 133e6:
+            raise ValueError('Clock frequency must be less than 133 MHz')
+        
+        self.external_clock = external_clock
+        self.clock_frequency = clock_frequency
+        # update specs based on clock frequency
+        if self.clock_frequency != 100e6:
+            # factor to scale times by
+            factor = 100e6/self.clock_frequency
+            self.resolution *= factor
+            self.minimum_duration *= factor
+            self.wait_delay *= factor
 
         IntermediateDevice.__init__(self, name, parent_device, **kwargs)
 
-        self.pod = Pod('pod', self, 'internal', 0)
+        self.pod = Pod('pod', self, self.minimum_duration)
 
-        self.BLACS_connection = 'PrawnDO: {}'.format(name)
+        self.BLACS_connection = com_port
 
     def add_device(self, device):
         if isinstance(device, DigitalOut):
-            (self.pod).add_device(device)
+            self.pod.add_device(device)
         else:
             IntermediateDevice.add_device(self, device)
-
 
 
     def generate_code(self, hdf5_file):
         IntermediateDevice.generate_code(self, hdf5_file)
 
-        # Creating a numpy array to take the times from the digital outputs
-        # where the program needs to change the output
-        times = []
-        times = np.asarray(times)
         bits = [0] * 16 # Start with a list of 16 zeros
         # Isolating the Pod child device in order to access the output change 
         # times to store in the array
-        for line in self.child_devices:
-            if isinstance(line, Pod):
-                # Retrieving all of the outputs contained within the pods and
-                # collecting/consolidating the times when they change
-                outputs = line.get_all_children()
-                times = line.get_update_times()
-                for output in outputs:
-                    # Retrieving the time series of each DigitalOut to be stored
-                    # as the output word for shifting to the pins
-                    output.make_timeseries(output.get_change_times())
-                    bits[int(output.connection, 16)] = np.asarray(output.timeseries, dtype = np.uint16)
+
+        # Retrieving all of the outputs contained within the pods and
+        # collecting/consolidating the times when they change
+        outputs = self.pod.get_all_children()
+        times = self.pod.get_update_times()
+        if len(times) == 0:
+            # no instructions, so return
+            return
+        
+        for output in outputs:
+            # Retrieving the time series of each DigitalOut to be stored
+            # as the output word for shifting to the pins
+            output.make_timeseries(times)
+            bits[int(output.connection, 16)] = np.asarray(output.timeseries, dtype = np.uint16)
         # Merge list of lists into an array with a single 16 bit integer column
         do_table = np.array(bitfield(bits, dtype=np.uint16))
 
-        # Making an array to store the number of reps needed for each output
-        # word
-        reps = []
-        reps = np.asarray(reps, dtype = int)
-
-        # Looping through each entry in the times array to calculate the number
-        # of 10ns reps between each output word
-        for i in range(1, times.size):
-            reps = np.append(reps, (int)(round((times[i] - times[i - 1]) / 10e-9)))
+        # Now create the reps array (ie times between changes in number of clock cycles)
+        reps = np.rint(np.diff(times)/self.resolution).astype(np.uint32)
         
+        # add stop command sequence
+        reps = np.append(reps, 0) # causes last instruction to hold
+        # next two indicate the stop
+        do_table = np.append(do_table, 0) # this value is ignored
         reps = np.append(reps, 0)
 
         # Looping through the waits given by the compiler's wait table to add 
@@ -129,17 +192,13 @@ class PrawnDO(IntermediateDevice):
         for wait in compiler.wait_table: 
             # Finding where the wait fits within the times array
             index = np.searchsorted(times, wait)
-            if index > 0:
             # Inserting the wait into the output word table and the reps table
-                do_table = np.insert(do_table, index, do_table[index - 1])
-            else:
-                do_table = np.insert(do_table, index, 0)
-
+            do_table = np.insert(do_table, index, do_table[index - 1])
             reps = np.insert(reps, index, 0)
 
         # Raising an error if the user adds too many commands, currently maxed 
         # at 23000
-        if reps.size > 23010:
+        if reps.size > self.max_instructions:
             raise LabscriptError (
                 "Too Many Commands"
             )
@@ -149,7 +208,6 @@ class PrawnDO(IntermediateDevice):
         # be used by the blacs worker to execute the sequence
         group.create_dataset('do_data', data=do_table)
         group.create_dataset('reps_data', data=reps)
-        group.create_dataset('times_data', data=times)
 
 
 class PrawnDOTrig(TriggerableDevice):


### PR DESCRIPTION
Edits bring functionality up to speed with firmware. Nominal functionality is present, but there are a number of issues outstanding.

- Using the PrawnDO as a triggerable device (instead of direct on a pseudoclock) is not working now
- wait delays are not accounted for
- Pretty sure the way commands from the individual outputs are collated is fragile in edge cases