### PR TITLE
Full refactor and update of labscript driver

### DIFF
--- a/blacs_tabs.py
+++ b/blacs_tabs.py
@@ -4,7 +4,7 @@ class PrawnDOTab(DeviceTab):
     def initialise_GUI(self):
         do_prop = {}
         for i in range(0, 16):
-            do_prop['0x{:01x}'.format(i)] = {}
+            do_prop['0x{:01X}'.format(i)] = {}
         self.create_digital_outputs(do_prop)
 
         _, _, do_widgets = self.auto_create_widgets()

--- a/blacs_workers.py
+++ b/blacs_workers.py
@@ -116,7 +116,7 @@ class PrawnDOWorker(Worker):
         Returns:
             dict: Dictonary with output channels as keys and values are boolean states
         """
-        return {hex(i):((val >> i) & 1) for i in range(16)}
+        return {f'0x{i:X}':((val >> i) & 1) for i in range(16)}
     
     def check_status(self):
         '''Checks operational status of the PrawnDO.

--- a/labscript_devices.py
+++ b/labscript_devices.py
@@ -98,11 +98,11 @@ class PrawnDO(PseudoclockDevice):
     "Minimum resolvable unit of time, corresponsd to system clock period."
     minimum_duration = 50e-9
     "Minimum time between updates on the outputs."
-    wait_delay = 40e-9
+    wait_delay = 50e-9
     "Minimum required length of wait before a retrigger can be detected."
     input_response_time = 50e-9
     "Time between hardware trigger and output starting."
-    trigger_delay = input_response_time
+    trigger_delay = 50e-9 # TODO: gets applied twice on waits...
     trigger_minimum_duration = 160e-9
     "Minimum required duration of hardware trigger. A fairly large over-estimate."
 

--- a/labscript_devices.py
+++ b/labscript_devices.py
@@ -222,7 +222,7 @@ class PrawnDODevice(PseudoclockDevice):
             self.__pod.add_device(device)
         else:
             raise LabscriptError(f"You have connected unsupported {device.name:s} (class {device.__class__:s}) "
-                                 "to {self.name:s}")
+                                 f"to {self.name:s}")
 
 
     def generate_code(self, hdf5_file):
@@ -337,3 +337,14 @@ class PrawnDO(IntermediateDevice):
                                       com_port,
                                       clock_frequency,
                                       external_clock))
+        
+    def add_device(self, device):
+
+        if isinstance(device, DigitalOut):
+            # pass Digital Outputs to PrawnDODevice
+            self.child_devices[0].add_device(device)
+        elif isinstance(PrawnDODevice) and not self.child_devices:
+            self.add_device(device)
+        else:
+            raise LabscriptError(f"You have connected unsupported {device.name:s} (class {device.__class__:s}) "
+                                 f"to {self.name:s}")

--- a/labscript_devices.py
+++ b/labscript_devices.py
@@ -7,7 +7,6 @@ from labscript import (
     Trigger,
     bitfield,
     set_passed_properties,
-    compiler,
     LabscriptError
 )
 import numpy as np

--- a/labscript_devices.py
+++ b/labscript_devices.py
@@ -329,11 +329,9 @@ class PrawnDO(IntermediateDevice):
         self.external_clock = external_clock
         self.clock_frequency = clock_frequency
 
-        IntermediateDevice.__init__(self, name, parent_device, **kwargs)
+        IntermediateDevice.__init__(self, f'{name:s}_dummy_parent', parent_device, **kwargs)
 
-        self.BLACS_connection = com_port
-
-        self._prawn_device = PrawnDODevice(f'{name:s}_device',
+        self._prawn_device = PrawnDODevice(f'{name:s}',
                                            self, 'internal',
                                            com_port,
                                            clock_frequency,

--- a/prawndo.rst
+++ b/prawndo.rst
@@ -77,6 +77,21 @@ An example connection table that uses the PrawnBlaster and PrawnDO:
 
         stop(1)
 
+.. note::
+
+    The PrawnDO is designed to be directly connected to a Clockline,
+    something not normally done for internally-timed devices in labscript.
+    This is merely for simplicity under the most typical use case of
+    adding standard digital output capability to a PrawnBlaster master pseudoclocking device.
+
+    When used in this way, the PrawnDO can share the Clockline with other devices
+    (especially with other PrawnDO boards!), but it is not advisable to share a Clockline
+    with devices that require many ticks (such as a DAQ).
+
+The PrawnDO can also be triggerd from a standard DigitalOut Trigger.
+In this case, the `clock_line` argument is not used,
+but the standard `trigger_device` and `trigger_connection` arguments.
+
 Synchronization
 ---------------
 

--- a/prawndo.rst
+++ b/prawndo.rst
@@ -1,0 +1,189 @@
+PrawnDO
+=======
+
+This labscript device controls the `PrawnDO <https://github.com/labscript-suite/prawn_digital_output>`_
+open-source digital output generator based on the
+`Raspberry Pi Pico <https://www.raspberrypi.org/documentation/rp2040/getting-started/>`_ platform.
+It is designed to be a companion device to the :doc:`PrawnBlaster <prawnblaster>` allowing for
+arbitrary digital output specification (in contrast to the variable pseudoclock generation of the PrawnBlaster).
+
+Specifications
+~~~~~~~~~~~~~~
+
+The PrawnDO takes advantage of the specs of the Pico to provide the following:
+
+* 16 synchronous digital outputs with timing specs equivalent to the PrawnBlaster
+  
+  - Timing resolution for an update is 1 clock cycle (10 ns at default 100 MHz clock)
+  - Minimum time between updates (on any output) is 5 clock cycles (50 ns with 100 MHz clock)
+  - Maximum time between updates (on any output) is 2^32-1 clock cycles (~42.9 s with 100 MHz clock)
+  - Updates are internally timed (ie only initial triggering is needed, not for every update)
+
+* 30,000 instructions (where each instruction can be held between 5 and 2^32-1 clock cycles)
+* Support for external hardware triggers to begin and re-start execution after a wait.
+* Can be referenced to an external LVCMOS clock
+* Internal clock can be set up to 133 MHz (which scales timing specs accordingly)
+
+
+Installation
+~~~~~~~~~~~~
+
+In order to turn the standard Pico into a PrawnDO, you need to load the custom firmware
+available in the `Github repo <https://github.com/labscript-suite/prawn_digital_output/tree/main/build/>`_ onto the board.
+The simplest way to do this is by holding the reset button on the board while plugging the USB into a computer.
+This will bring up a mounted folder that you copy-paste the firmware to.
+Once copied, the board will reset and be ready to go.
+
+Note that this device communicates using a virtual COM port.
+The number is assigned by the controlling computer and will need to be determined in order for BLACS to connect to the PrawnDO.
+
+
+Usage
+~~~~~
+
+The pinout for the PrawnDO is as follows:
+
+* Outputs 0-15 (labelled by default in hex 0-F): GPIO pins 0-15, respectively.
+* External Trigger input: GPIO 16
+* External Clock input: GPIO 20
+
+Note that signal cables should be connected to the Pico digital grounds for proper operation.
+
+The PrawnDO can provide up to 16 digital outputs, which are accessed via `name.outputs`.
+Each channel is specified using the corresponding hex character (spanning 0-F for 0-15).
+The channel string must end with a single character between 0-F to be valid
+(i.e. `'flag 0'`, `'do 0'`, and `'0'` are all valid channel specifications for GPIO 0 of the PrawnDO).
+
+An example connection table that uses the PrawnBlaster and PrawnDO:
+
+.. code-block:: python
+
+    from labscript import *
+
+    from labscript_devices.PrawnBlaster.labscript_devices import PrawnBlaster
+    from labscript_devices.PrawnDO.labscript_devices import PrawnDO
+
+    PrawnBlaster(name='prawn', com_port='COM6', num_pseudoclocks=1)
+
+    PrawnDO(name='prawn_do', com_port='COM5', clock_line=prawn.clocklines[0])
+
+    DigitalOut('do0', prawn_do.outputs, 'flag 0')
+    DigitalOut('do1', prawn_do.outputs, 'chan 1')
+    DigitalOut('do10', prawn_do.outputs, 'flag C')
+
+    if __name__ == "__main__":
+
+        start()
+
+        stop(1)
+
+Synchronization
+---------------
+
+The PrawnDO generates output based on internal timing with external starting triggers
+in a manner nearly equivalent to the PrawnBlaster.
+This means that under a typical use case of a PrawnBlaster used with a PrawnDO,
+the output timings of the devices will drift as their internal clocks drift.
+Each Pico is specified to have a clock with better than 50 ppm stability,
+meaning drift could be as bad as 100 ppm between two devices 
+(e.g. 100 microsecond drift after 1 second of run time).
+In practice, relative drift is often around 5 ppm.
+
+To overcome this, either use labscript waits right before sensitive operations
+to resynchronize back to with a single clock cycle (:math:`\pm10` ns),
+or use a common external clock for both devices.
+
+Unless buffering/level protecting circuitry is used,
+both the PrawnBlaster and the PrawnDO require LVCMOS square-wave clock signals.
+An example evaluation board with a flexible, multi-channel LVCMOS clock generator is
+the SI535X-B20QFN-EVB.
+Note that interrupting the external clock can cause the Pico serial communication to freeze.
+Recovery requires resetting the board via a power cycle or shorting the RUN pin to ground
+to re-enable default options including the internal clock.
+
+An example connection table using external clocks with the default frequency of 100 MHz is:
+
+.. code-block:: python
+
+    from labscript import *
+
+    from labscript_devices.PrawnBlaster.labscript_devices import PrawnBlaster
+    from labscript_devices.PrawnDO.labscript_devices import PrawnDO
+
+    PrawnBlaster(name='prawn', com_port='COM6', num_pseudoclocks=1,
+                 external_clock_pin=20)
+
+    PrawnDO(name='prawn_do', com_port='COM5', clock_line=prawn.clocklines[0],
+            external_clock=True)
+
+    DigitalOut('do0', prawn_do.outputs, 'flag 0')
+    DigitalOut('do1', prawn_do.outputs, 'chan 1')
+    DigitalOut('do10', prawn_do.outputs, 'flag C')
+
+    if __name__ == "__main__":
+
+        start()
+
+        stop(1)
+
+
+Input/Output Buffers
+--------------------
+
+While the PrawnBlaster and PrawnDO boards can be used as is,
+it is often a good idea to add unity-gain channel buffers to the inputs and outputs.
+Using buffers and line drivers from a LVCMOS family with 5V/TTL tolerant inputs can provide
+compatibility with TTL inputs and drive higher capacitance loads (such a long BNC cables) more reliably.
+An example that implements these buffers can be found `here <https://github.com/TU-Darmstadt-APQ/Prawnblaster_Breakout>`_.
+
+Waits
+-----
+
+All waits in the PrawnDO are indefinite waits in the parlance of the PrawnBlaster.
+This means they will never time out, but must have an external trigger to restart execution.
+Changing a digital output state concurrently with a wait
+results in the PrawnDO output holding the updated value during the wait.
+For example, in the following code snippet, the output of `do0` will be low during the wait.
+For the output of `do0` to be high during the wait,
+the second instruction must be at least 5 clock cycles after the wait time.
+
+.. code-block:: python
+
+    t = 0
+    do.go_high(t)
+    t = 1e-3
+    wait('my_wait', t)
+    do0.go_low(t)
+
+Detailed Documentation
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: labscript_devices.PrawnDO
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :private-members:
+
+.. automodule:: labscript_devices.PrawnDO.labscript_devices
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :private-members:
+
+.. automodule:: labscript_devices.PrawnDO.blacs_tabs
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :private-members:
+
+.. automodule:: labscript_devices.PrawnDO.blacs_workers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :private-members:
+
+.. automodule:: labscript_devices.PrawnDO.runviewer_parsers
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    :private-members:

--- a/prawndo.rst
+++ b/prawndo.rst
@@ -84,9 +84,14 @@ An example connection table that uses the PrawnBlaster and PrawnDO:
     This is merely for simplicity under the most typical use case of
     adding standard digital output capability to a PrawnBlaster master pseudoclocking device.
 
-    When used in this way, the PrawnDO can share the Clockline with other devices
-    (especially with other PrawnDO boards!), but it is not advisable to share a Clockline
-    with devices that require many ticks (such as a DAQ).
+    When used in this way, the PrawnDO can share the Clockline with other devices,
+    especially with other PrawnDO boards allowing for significant fan-out.
+    Nominally, the PrawnDO will ignore clock ticks from other devices on the same Clockline,
+    such as a DAQ.
+    However, standard cautions should be taken when sharing a clockline between devices
+    (i.e. don't overload the physical output driver with too many parallel devices, 
+    limit number of devices doing fast things at nearly the same times,
+    validate critical timings/operations independently). 
 
 The PrawnDO can also be triggerd from a standard DigitalOut Trigger.
 In this case, the `clock_line` argument is not used,
@@ -104,8 +109,8 @@ meaning drift could be as bad as 100 ppm between two devices
 (e.g. 100 microsecond drift after 1 second of run time).
 In practice, relative drift is often around 5 ppm.
 
-To overcome this, either use labscript waits right before sensitive operations
-to resynchronize back to with a single clock cycle (:math:`\pm10` ns),
+To overcome this, either use labscript waits right before time-sensitive operations
+to resynchronize back to within a single clock cycle (:math:`\pm10` ns),
 or use a common external clock for both devices.
 
 Unless buffering/level protecting circuitry is used,

--- a/register_classes.py
+++ b/register_classes.py
@@ -5,10 +5,3 @@ register_classes(
     BLACS_tab='naqslab_devices.prawn_digital_output_labscript.blacs_tabs.PrawnDOTab',
     runviewer_parser='naqslab_devices.prawn_digital_output_labscript.runviewer_parsers.PrawnDOParser',
 )
-
-
-register_classes(
-    'PrawnDODevice',
-    BLACS_tab='naqslab_devices.prawn_digital_output_labscript.blacs_tabs.PrawnDOTab',
-    runviewer_parser=None,
-)

--- a/register_classes.py
+++ b/register_classes.py
@@ -2,13 +2,13 @@ from labscript_devices import register_classes
 
 register_classes(
     'PrawnDO',
-    BLACS_tab='naqslab_devices.prawn_do.blacs_tabs.PrawnDOTab',
-    runviewer_parser='naqslab_devices.prawn_do.runviewer_parsers.PrawnDOParser',
+    BLACS_tab='naqslab_devices.prawn_digital_output_labscript.blacs_tabs.PrawnDOTab',
+    runviewer_parser='naqslab_devices.prawn_digital_output_labscript.runviewer_parsers.PrawnDOParser',
 )
 
 
 register_classes(
-    'PrawnDOTrig',
-    BLACS_tab='naqslab_devices.prawn_do.blacs_tabs.PrawnDOTab',
+    'PrawnDODevice',
+    BLACS_tab='naqslab_devices.prawn_digital_output_labscript.blacs_tabs.PrawnDOTab',
     runviewer_parser=None,
 )

--- a/register_classes.py
+++ b/register_classes.py
@@ -5,3 +5,9 @@ register_classes(
     BLACS_tab='naqslab_devices.prawn_digital_output_labscript.blacs_tabs.PrawnDOTab',
     runviewer_parser='naqslab_devices.prawn_digital_output_labscript.runviewer_parsers.PrawnDOParser',
 )
+
+register_classes(
+    '_PrawnDOIntermediateDevice',
+    BLACS_tab='',
+    runviewer_parser='naqslab_devices.prawn_digital_output_labscript.runviewer_parsers._PrawnDOIntermediateParser'
+)

--- a/runviewer_parsers.py
+++ b/runviewer_parsers.py
@@ -14,59 +14,67 @@ class PrawnDOParser(object):
     def get_traces(self, add_trace, clock = None):
 
 
-        # Getting the waits, output words, and update times from the shot file
+        if clock is not None:
+            times, clock_value = clock[0], clock[1]
+            clock_indices = np.where((clock_value[1:] - clock_value[:-1]) == 1)[0] + 1
+            # If initial clock value is 1, then this counts as a rising edge
+            # (clock should be 0 before experiment) but this is not picked up
+            # by the above code. So we insert it!
+            if clock_value[0] == 1:
+                clock_indices = np.insert(clock_indices, 0, 0)
+            clock_ticks = times[clock_indices]
+
+        # Getting output words, and update times from the shot file
         with h5py.File(self.path, "r") as f:
-            waits = (f['waits'][:])
+            device_props = properties.get(f, self.name, 'device_properties')
+            self.clock_resolution = device_props['clock_resolution']
+            self.trigger_delay = device_props['trigger_delay']
+            self.wait_delay = device_props['wait_delay']
+
+            waits = f['waits'][()]
             group = f['devices/' + self.name]
 
-            do_table = group['do_data'][:]
-            times_table = group['times_data'][:]
-            times_table = np.array(times_table)
-            do_table = np.array(do_table)
+            do_table = group['do_data'][()]
+            reps_table = group['reps_data'][()]
+            times_table = np.cumsum(np.insert(reps_table,0,0)*self.clock_resolution)
 
-            # Removing the waits from the output word table to prevent wrong
-            # output trace
-            for wait, time, timeout in waits:
-                index = np.searchsorted(times_table, time)
-                do_table = np.delete(do_table, index)
-                
-            
+        # Removing the waits from the output word table to prevent wrong
+        # output trace
+        for wait, time, timeout in waits:
+            index = np.searchsorted(times_table, time)
+            do_table = np.delete(do_table, index)
+        
+        # convert do_table back to individual bits for each output
+        do_bitfield = np.fliplr( # reverse bit order for indexing by label
+            np.unpackbits(
+                do_table.reshape(do_table.shape + (1,) # reshape so unpackbits does each number separate
+                                 ).byteswap().view(np.uint8), # switch endianness, view at uint8 for unpackbits
+                                 axis=1) # unpack along time axis
+        )
 
         digital_outs = {}
 
-        for digiout_name, digiout in self.device.child_list.items():
-            # Ignoring the internal pod child object
-            if not digiout_name == "pod":
-                # This is for if the triggerable prawndo is attached, preventing
-                # the runviewer parser from trying to read the parent trigger device
-                # if it's a digitalout of the prawndo
-                for trig in digiout.child_list:
-                    digiout.child_list = {}
-                
-                do_states = []
-
-                # Reading in the output word from the table and making an array
-                # for each output to show when they should go high or low
-                for word in do_table:
-                    if (((word >> ((int(digiout.parent_port, 16)) % 16)) & 1) == 1):
-                        do_states.append(1.0)
-                    else:
-                        do_states.append(0.0)
-                                   
-                # Storing the output trace as the update times and the states
-                # of the digitalouts at those given times
-                output_trace = (times_table, np.array(do_states))
-
-                name = "do%d" % int(digiout.parent_port, 16)
-
-                digital_outs[name] = output_trace
-
-                # Adding the trace to the runviewer parser
-                add_trace(
-                    name,
-                    output_trace,
-                    self.name,
-                    digiout.parent_port
-                )
+        # work down the tree of parent devices to the digital outputs
+        for pseudoclock_name, pseudoclock in self.device.child_list.items():
+            for clock_line_name, clock_line in pseudoclock.child_list.items():
+                for internal_device_name, internal_device in clock_line.child_list.items():
+                    for channel_name, channel in internal_device.child_list.items():
+                        chan = channel.parent_port.split(' ')[-1]
+                        output_trace = (times_table, do_bitfield[:,int(chan,16)])
+                        digital_outs[channel_name] = output_trace
+                        add_trace(channel_name, output_trace,
+                                  self.name, channel.parent_port)
             
         return digital_outs
+
+
+class _PrawnDOIntermediateParser(object):
+
+    def __init__(self, path, device):
+        self.path = path
+        self.name = device.name
+        self.device = device
+
+    def get_traces(self, add_trace, clock = None):
+
+        return {list(self.device.child_list.keys())[0]: clock}

--- a/runviewer_parsers.py
+++ b/runviewer_parsers.py
@@ -31,6 +31,7 @@ class PrawnDOParser(object):
             self.trigger_delay = device_props['trigger_delay']
             self.wait_delay = device_props['wait_delay']
 
+            waits = f['waits'][()]
             group = f['devices/' + self.name]
 
             do_table = group['do_data'][()]
@@ -43,17 +44,14 @@ class PrawnDOParser(object):
         # re-add trigger delay
         trigger_index = 0
         t = 0 if clock is None else clock_ticks[trigger_index] + self.trigger_delay
-        trigger_index += 1
         time_deltas_table[0] += t
         # re-add wait delays (ignoring final one, which is from the 1st part of stop command)
         wait_idxs = np.nonzero(reps_table==0)[0][:-1]
         for wait_idx in wait_idxs:
             if clock is not None:
-                t = clock_ticks[trigger_index] + self.trigger_delay
-                trigger_index += 1
+                t = self.trigger_delay
             else:
-                t += self.wait_delay
-
+                t = self.wait_delay
             time_deltas_table[wait_idx] += t
         # insert t=0 for cumsum, remove final value (from stop instruction)
         times_table = np.cumsum(np.insert(time_deltas_table,0,0.0))[:-1]

--- a/runviewer_parsers.py
+++ b/runviewer_parsers.py
@@ -31,7 +31,6 @@ class PrawnDOParser(object):
             self.trigger_delay = device_props['trigger_delay']
             self.wait_delay = device_props['wait_delay']
 
-            waits = f['waits'][()]
             group = f['devices/' + self.name]
 
             do_table = group['do_data'][()]


### PR DESCRIPTION
Finished the refactor of the labscript driver to match advice from @philipstarkey. To the surprise of no one, actually conforming to the design of labscript has led to significantly cleaner device code.

Basic structure is
- `PrawnDODevice`: a `PseudoclockDevice` that does all of the actual work.
  - `PrawnDoDevice.outputs`: an internal `IntermediateDevice` that holds all of the `DigitalOut` outputs. Outputs must be directly connected to it, not the `PrawnDODevice` to work.
- `PrawnDO`: a dummy `IntermediateDevice` that allows for directly connecting a PrawnDO to a Clockline (rather than via a DigitalOutput Trigger).
  - When using this device, the name supplied by the user is applied to the auto-created `PrawnDODevice`. So the user is actually interacting with that, not the dummy class.

Have confirmed that this code properly accounts for specified re-trigger delays. I've also tidied up my test rig (ie used cables all of the same length) and confirm the delay is 50ns.

Before merging this, should go ahead and merge #3. I'd also like to stress-test using the driver a bit more to make sure there aren't any edge cases that need to be fixed.