### PR TITLE
Re-add definition for total_inst

### DIFF
--- a/blacs_workers.py
+++ b/blacs_workers.py
@@ -195,6 +195,7 @@ class PrawnDOWorker(Worker):
 
         # check if it is more efficient to fully refresh
         if not fresh and self.smart_cache['do_table'] is not None:
+            total_inst = len(reps)
             # get more convenient handles to smart cache arrays
             curr_do = self.smart_cache['do_table']
             curr_reps = self.smart_cache['reps']


### PR DESCRIPTION
The definition of total_inst was deleted in a previous commit, causing errors. This pull request re-adds it.